### PR TITLE
Fix chess piece css bug

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -78,6 +78,8 @@ export default class Board {
 					}
 					console.log(this.status)
 				}
+				this.draggedPiece.style.top = null;
+				this.draggedPiece.style.left = null;
 				this.draggedPiece.style.position = null;
 				this.draggedPiece.style.zIndex = 0;
 				this.draggedPiece = null;


### PR DESCRIPTION
Fixes bug where chess piece would visually be placed incorrectly onmousemove after user onmouseup on an invalid board position